### PR TITLE
Add item/active effect reset scripts

### DIFF
--- a/development/resetActorActiveEffects.js
+++ b/development/resetActorActiveEffects.js
@@ -1,0 +1,11 @@
+/**
+ * Quickly reset an actor's active effects.
+ * @version 0.8.9
+ */
+(async () => {
+	const ACTOR_ID = "<your ID here>";
+
+	const ids = CONFIG.Actor.collection.instance.get(ACTOR_ID).data.effects.map(it => it.id);
+	await CONFIG.Actor.collection.instance.get(ACTOR_ID)
+		.deleteEmbeddedDocuments("ActiveEffect", ids);
+})();

--- a/development/resetActorDetails.js
+++ b/development/resetActorDetails.js
@@ -1,5 +1,6 @@
 /**
  * Quickly (re)set all an actor's proficiencies, senses, damage res./vuln./imm., condition imm., race, background, ...
+ * @version 0.8.9
  */
 (async () => {
 	const ACTOR_ID = "<your ID here>";
@@ -11,7 +12,7 @@
 	// Feet/etc.
 	const SENSE_RANGE = 0;
 
-	await Actor.collection.get(ACTOR_ID)
+	await CONFIG.Actor.collection.instance.get(ACTOR_ID)
 		.update({
 			data: {
 				abilities: Object.keys(CONFIG.DND5E.abilities)

--- a/development/resetActorItems.js
+++ b/development/resetActorItems.js
@@ -1,0 +1,11 @@
+/**
+ * Quickly reset an actor's items.
+ * @version 0.8.9
+ */
+(async () => {
+	const ACTOR_ID = "<your ID here>";
+
+	const ids = CONFIG.Actor.collection.instance.get(ACTOR_ID).data.items.map(it => it.id);
+	await CONFIG.Actor.collection.instance.get(ACTOR_ID)
+		.deleteEmbeddedDocuments("Item", ids);
+})();


### PR DESCRIPTION
Also updated the original "actor reset" script to work under `0.8.x` Foundry. Going to start (ab)using the JSDoc `@version` tag to represent which Foundry version a macro is supposed to work under.