### PR TITLE
fix(camtrack): fix hook leak and update for 0.8.x+

### DIFF
--- a/cameraTrackToken.js
+++ b/cameraTrackToken.js
@@ -11,17 +11,15 @@
 
 	window.__cameraTrackToken_token = token;
 
-	if (window.__cameraTrackToken_active != null) {
-		window.__cameraTrackToken_active = !window.__cameraTrackToken_active;
+	if (window.__cameraTrackToken_idHook != null) {
+		Hooks.off("preUpdateToken", window.__cameraTrackToken_idHook);
+		window.__cameraTrackToken_idHook = null;
 		return;
 	}
 
-	window.__cameraTrackToken_active = true;
-
-	Hooks.on("preUpdateToken", async (scene, token, updateData) => {
-		if (!window.__cameraTrackToken_active) return;
+	window.__cameraTrackToken_idHook = Hooks.on("preUpdateToken", async (token, updateData, options, userId) => {
 		if (updateData.x == null && updateData.y == null) return;
-		if (window.__cameraTrackToken_token.id !== token._id) return;
+		if (window.__cameraTrackToken_token.id !== token.id) return;
 
 		if (token.x !== updateData.x || token.y !== updateData.y) {
 			const xOffsetSidebar = (ui.sidebar._collapsed ? 0 : 1) * (W_SIDEBAR / 2);


### PR DESCRIPTION
Previously, each time the macro was run, it would create a new hook,
each of which would run on token movement. Now, the hook ID is tracked,
and the old hook removed if the macro is re-run.

Additionally, the 0.8.x Foundry update changed the token hook API, so
the hook arguments have been adjusted to reflect this.